### PR TITLE
Fork test success!

### DIFF
--- a/devices/disk.c
+++ b/devices/disk.c
@@ -66,7 +66,9 @@ struct disk {
 };
 
 /* An ATA channel (aka controller).
-   Each channel can control up to two disks. */
+   Each channel can control up to two disks.
+   ATA 채널은 최대 두 개의 ATA 디바이스(Master/Slave)를
+   시스템에 연결하기 위한 경로를 제공한다. */
 struct channel {
 	char name[8];               /* Name, e.g. "hd0". */
 	uint16_t reg_base;          /* Base I/O port. */
@@ -180,11 +182,20 @@ disk_print_stats (void) {
 /* Returns the disk numbered DEV_NO--either 0 or 1 for master or
    slave, respectively--within the channel numbered CHAN_NO.
 
+   DEV_NO로 번호 지정된 디스크를 반환합니다. 0 또는 1은 각각 마스터와 슬레이브를 나타냅니다.
+   이는 CHAN_NO로 번호 지정된 채널 내에서 사용됩니다.
+
+   Pintos는 디스크를 다음과 같은 방식으로 사용합니다:
+   0:0 - 부트 로더, 커맨드 라인 인수, 그리고 운영 체제 커널
+   0:1 - 파일 시스템
+   1:0 - 스크래치(임시 저장공간)
+   1:1 - 스왑
+
    Pintos uses disks this way:
-0:0 - boot loader, command line args, and operating system kernel
-0:1 - file system
-1:0 - scratch
-1:1 - swap
+   0:0 - boot loader, command line args, and operating system kernel
+   0:1 - file system
+   1:0 - scratch
+   1:1 - swap
 */
 struct disk *
 disk_get (int chan_no, int dev_no) {

--- a/do.sh
+++ b/do.sh
@@ -151,6 +151,7 @@ make -j
 cd build
 source ../../activate
 
-# $PT_GROW_BAD
-$PT_BIG_STK_OBJ
+$ARGS_NONE
+# $PT_WRITE_CODE
+# $PT_WRITE_CODE
 # pintos -v -k  -m 20  --fs-disk=10 -p tests/userprog/args-multiple:args-multiple --swap-disk=4 -- -q   -f run 'args-multiple some arguments for you!'

--- a/do.sh
+++ b/do.sh
@@ -151,7 +151,7 @@ make -j
 cd build
 source ../../activate
 
-$ARGS_NONE
+$FORK_ONCE
 # $PT_WRITE_CODE
 # $PT_WRITE_CODE
 # pintos -v -k  -m 20  --fs-disk=10 -p tests/userprog/args-multiple:args-multiple --swap-disk=4 -- -q   -f run 'args-multiple some arguments for you!'

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -1,10 +1,15 @@
 #ifndef VM_ANON_H
 #define VM_ANON_H
+
 #include "vm/vm.h"
+#include "devices/disk.h"
+
 struct page;
 enum vm_type;
 
-struct anon_page {};
+struct anon_page {
+    disk_sector_t disk_sec;
+};
 
 void vm_anon_init(void);
 bool anon_initializer(struct page *page, enum vm_type type, void *kva);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -127,4 +127,7 @@ void vm_dealloc_page(struct page *page);
 bool vm_claim_page(void *va);
 enum vm_type page_get_type(struct page *page);
 
+/* Install page. */
+bool install_page(struct page *page);
+
 #endif /* VM_VM_H */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -38,7 +38,10 @@ struct page_operations;
 struct thread;
 
 #define VM_TYPE(type) ((type) & 7)
+
+/* Check page flag bits. */
 #define pg_writable(page) ((page->flags & PTE_W ) != 0)
+#define pg_present(page) ((page->flags & PTE_P ) != 0)
 
 /* The representation of "page".
  * This is kind of "parent class", which has four "child class"es, which are
@@ -95,6 +98,11 @@ struct supplemental_page_table {
   /* SPT - Use hash table. */
   void* stack_bottom;
   struct hash hash;
+};
+
+/* Swap table structure. */
+struct swap_page_table {
+
 };
 
 #include "threads/thread.h"

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -839,16 +839,21 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   bool writable = pg_writable(page);
 
   /* Load this page. */
+  printf("🚨 file: %p, ofs: %d, bytes: %d\n", file, ofs, bytes);
   file_seek(file, ofs);
   if (file_read(file, kva, bytes) != (int)bytes) {
     PANIC("process.c:838 File is not read properly.\n");
   }
 
   /* Set page in current thread's pml4. */
-  if (pml4_get_page(curr->pml4, page->va) != NULL) {
+  if (pml4_get_page(curr->pml4, upage) != NULL) {
     printf("evict the page?\n");
   } else {
-    succ = pml4_set_page(curr->pml4, page->va, kva, writable);
+    succ = pml4_set_page(curr->pml4, upage, kva, writable);
+    uint64_t *pte = pml4e_walk(curr->pml4, upage, 0);
+    if (pte) {
+      printf("🩷 pml4: upage %p, writable: %d, pa %p / frame %p\n", upage, is_writable(pte), *pte, kva);
+    }
   }
 
   /* Free file info. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -196,7 +196,6 @@ static void __do_fork(void *aux) {
   if (!supplemental_page_table_copy(&curr->spt, &parent->spt)) goto error;
 #else
   if (!pml4_for_each(parent->pml4, duplicate_pte, parent)) goto error;
-
 #endif
 
   /* Get new page for fdt. */
@@ -822,13 +821,13 @@ static struct file_info {
 static bool lazy_load_segment(struct page *page, void *aux) {
   struct thread *curr = thread_current();
   void *upage = page->va;
-  bool succ = false;
 
   /* Get a page of memory. */
   struct frame *frame = page->frame;
   void *kva = frame->kva;
   if (frame == NULL || kva == NULL) {
-    PANIC("process.c:827 No frame is allocated.\n");
+    printf("process.c:827 No frame is allocated.\n");
+    return false;
   }
 
   /* File information to read. */
@@ -839,26 +838,15 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   bool writable = pg_writable(page);
 
   /* Load this page. */
-  printf("🚨 file: %p, ofs: %d, bytes: %d\n", file, ofs, bytes);
   file_seek(file, ofs);
   if (file_read(file, kva, bytes) != (int)bytes) {
-    PANIC("process.c:838 File is not read properly.\n");
-  }
-
-  /* Set page in current thread's pml4. */
-  if (pml4_get_page(curr->pml4, upage) != NULL) {
-    printf("evict the page?\n");
-  } else {
-    succ = pml4_set_page(curr->pml4, upage, kva, writable);
-    uint64_t *pte = pml4e_walk(curr->pml4, upage, 0);
-    if (pte) {
-      printf("🩷 pml4: upage %p, writable: %d, pa %p / frame %p\n", upage, is_writable(pte), *pte, kva);
-    }
+    printf("process.c:838 File is not read properly.\n");
+    return false;
   }
 
   /* Free file info. */
   free(file_info);
-  return succ;
+  return true;
 }
 
 /* Loads a segment starting at offset OFS in FILE at address

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -4,6 +4,7 @@
 
 #include "devices/disk.h"
 #include "vm/vm.h"
+#include "vm/anon.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -21,8 +22,8 @@ static const struct page_operations anon_ops = {
 
 /* Initialize the data for anonymous pages */
 void vm_anon_init(void) {
-  /* TODO: Set up the swap_disk. */
-  swap_disk = NULL;
+  /* Set up the swap_disk. */
+  swap_disk = disk_get(1, 1);
 }
 
 /* Initialize the file mapping */
@@ -30,7 +31,10 @@ bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
   /* Set up the handler */
   page->operations = &anon_ops;
   struct anon_page *anon_page = &page->anon;
-  
+
+  *anon_page = (struct anon_page){
+                    .disk_sec = 0,
+                };
   return true;
 }
 
@@ -42,7 +46,12 @@ static bool anon_swap_in(struct page *page, void *kva) {
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool anon_swap_out(struct page *page) {
+  ASSERT(page->frame && page->frame->kva)
+
   struct anon_page *anon_page = &page->anon;
+
+  /* find free disk sector */
+//   disk_write(swap_disk, anon_page->disk_sec)
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -55,7 +55,7 @@ static bool uninit_initialize(struct page *page, void *kva) {
 
   /* TODO: You may need to fix this function. */
   return uninit->page_initializer(page, uninit->type, kva) &&
-         (init ? init(page, aux) : true);
+         (init ? init(page, aux) : true) && install_page(page);
 }
 
 /* Free the resources hold by uninit_page. Although most of pages are transmuted

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -26,6 +26,7 @@ void vm_init(void) {
 #endif
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
+
   /* TODO: Your code goes here. */
 }
 
@@ -48,6 +49,7 @@ static bool vm_do_claim_page(struct page *page);
 static struct frame *vm_evict_frame(void);
 static bool install_page(struct page *page);
 
+/* Install page in current thread's pml4. */
 static bool install_page(struct page *page) {
   struct thread *curr = thread_current();
   bool writable = pg_writable(page);
@@ -69,6 +71,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
                                     bool writable, vm_initializer *init,
                                     void *aux) {
   ASSERT(VM_TYPE(type) != VM_UNINIT)
+  ASSERT(((uint64_t)upage % PGSIZE) == 0)
 
   struct supplemental_page_table *spt = &thread_current()->spt;
   struct page *page = calloc(1, sizeof(struct page));
@@ -95,7 +98,8 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
       printf("vm.c:75 spt insert failed\n");
       goto err;
     }
-    /* 만약 스택 페이지이면 즉시 claim */
+
+    /* If stack page, claim immediately. */
     if (upage == spt->stack_bottom && vm_do_claim_page(page)) {
       return install_page(page);
     }
@@ -111,7 +115,7 @@ struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
   struct page *page = NULL;
   struct page tmp;
 
-  /* align */
+  /* Align to page size. */
   tmp.va = pg_round_down(va);
 
   spt_elem = hash_find(&spt->hash, &tmp.elem);
@@ -185,7 +189,7 @@ static struct frame *vm_get_frame(void) {
 
 /* Growing the stack. */
 static bool vm_stack_growth(void *addr) {
-  /* If addr exceeds STACK_LIMIT, */
+  /* If addr exceeds STACK_LIMIT, return false. */
   if (addr <= STACK_LIMIT) {
     return false;
   }
@@ -202,14 +206,17 @@ static bool vm_handle_wp(struct page *page UNUSED) {}
 bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user,
                          bool write, bool not_present) {
   struct supplemental_page_table *spt = &thread_current()->spt;
+  void *upage = pg_round_down(addr);
   void *curr_rsp = (void *)f->rsp;
+
+  printf("🥑 fault addr: %p\n", upage);
 
   /* Validate stack overflow. */
   if (STACK_LIMIT < addr && addr < spt->stack_bottom) {
     /* If current stack is not full, not a stack overflow. */
     if (curr_rsp != addr) return false;
     /* If stack overflow */
-    return vm_stack_growth(pg_round_down(addr));
+    return vm_stack_growth(upage);
   }
 
   /* Else, search for page in spt. */
@@ -222,6 +229,7 @@ bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user,
   if (write && !pg_writable(page)) {
     return false;
   }
+  printf("💜 spt: upage: %p, writable: %d\n", upage, pg_writable(page));
 
   /* Else, lazy loading. */
   return vm_do_claim_page(page);
@@ -251,6 +259,9 @@ static bool vm_do_claim_page(struct page *page) {
   frame->page = page;
   page->frame = frame;
 
+  /* Mark as present */
+  page->flags = page->flags | PTE_P;
+
   /* Initialize page */
   return swap_in(page, frame->kva);
 }
@@ -270,10 +281,16 @@ void supplemental_page_table_init(struct supplemental_page_table *spt) {
 static void spt_copy_page(struct hash_elem *e, void *aux) {
   struct hash *dsc_hash = (struct hash *)aux;
   struct page *src_page = hash_entry(e, struct page, elem);
-  struct page *dsc_page = malloc(sizeof(struct page));
+
+  /* Copy spt entries. */
+  struct page *dsc_page = calloc(1, sizeof(struct page));
   memcpy(dsc_page, src_page, sizeof(struct page));
-  dsc_page->frame = NULL;
   hash_insert(dsc_hash, &dsc_page->elem);
+
+  /* Claim page if need. */
+  if (pg_present(dsc_page)) {
+        install_page(dsc_page);
+  }
 }
 
 /* SPT - Copy supplemental page table from src to dst */


### PR DESCRIPTION
supplementary_table_copy 함수 구현

```
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
pass tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
pass tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
```